### PR TITLE
Tray and Gui improvements

### DIFF
--- a/Software/Source/src/pijuice_cli.py
+++ b/Software/Source/src/pijuice_cli.py
@@ -1223,7 +1223,7 @@ choices = ["Status", "General", "Buttons", "LEDs", "Battery profile",
 
 main = urwid.Padding(menu("PiJuice HAT CLI", choices), left=2, right=2)
 top = urwid.Overlay(main, urwid.SolidFill(u'\N{MEDIUM SHADE}'),
-    align='center', width=('relative', 80),
-    valign='middle', height=('relative', 80),
-    min_width=20, min_height=9)
+                    align='center', width=('relative', 80),
+                    valign='middle', height=('relative', 80),
+                    min_width=20, min_height=9)
 urwid.MainLoop(top, palette=[('reversed', 'standout', '')]).run()

--- a/Software/Source/src/pijuice_gui.py
+++ b/Software/Source/src/pijuice_gui.py
@@ -15,7 +15,9 @@ import sys
 import time
 from signal import SIGUSR1, SIGUSR2
 
-try:
+py3 = sys.version_info > (3, 0)
+
+if not py3:
     # Python 2
     from Tkinter import Button as tkButton
     from Tkinter import (Tk, BooleanVar, IntVar, StringVar, Toplevel,
@@ -25,7 +27,7 @@ try:
     from tkColorChooser import askcolor
     from tkFileDialog import askopenfilename
     import tkMessageBox as MessageBox
-except ImportError:
+else:
     # Python 3
     from tkinter import Button as tkButton
     from tkinter import (Tk, BooleanVar, IntVar, StringVar, Toplevel,
@@ -1678,6 +1680,7 @@ class PiJuiceHatTab(object):
 
     def _SetSysSwitch(self, *args):
         pijuice.power.SetSystemPowerSwitch(self.sysSwLimit.get())
+
     def _HatConfigCmd(self):
         if pijuice != None:
             self.advWindow = PiJuiceHATConfigGui(self.hatConfigBtn)
@@ -1818,7 +1821,7 @@ def start_app():
         fcntl.lockf(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except IOError:
         root.withdraw()
-        MessageBox.showerror('PiJucie Settings', 'An other instance of PiJuice Settings is already running')
+        MessageBox.showerror('PiJucie Settings', 'Another instance of PiJuice Settings is already running')
         sys.exit()
 
     # Send signal to pijuice_tray to disable the 'Settings' menuitem

--- a/Software/Source/src/pijuice_tray.py
+++ b/Software/Source/src/pijuice_tray.py
@@ -13,15 +13,15 @@ from signal import signal, SIGUSR1, SIGUSR2
 py3 = sys.version_info > (3, 0)
 
 if py3 == False:
-	# Python 2
-	import gtk
-	import gobject
+    # Python 2
+    import gtk
+    import gobject
 else:
-	# Python 3
-	import gi
-	gi.require_version('Gtk', '3.0')
-	from gi.repository import Gtk as gtk
-	from gi.repository import GObject as gobject
+    # Python 3
+    import gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk as gtk
+    from gi.repository import GObject as gobject
 
 from pijuice import PiJuice, get_versions
 from pijuice_gui import start_app
@@ -34,168 +34,168 @@ TRAY_PID_FILE = '/tmp/pijuice_tray.pid'
 
 class PiJuiceStatusTray(object):
 
-	def __init__(self):
-		self.tray = gtk.StatusIcon()
-		self.tray.connect('activate', self.refresh)
+    def __init__(self):
+        self.tray = gtk.StatusIcon()
+        self.tray.connect('activate', self.refresh)
 
-		# Create menu
-		self.menu = gtk.Menu()
+        # Create menu
+        self.menu = gtk.Menu()
 
-		i = gtk.MenuItem("Settings")
-		self.settings_item = i
-		i.show()
-		i.connect("activate", self.ConfigurePiJuice)
-		self.menu.append(i)
+        i = gtk.MenuItem("Settings")
+        self.settings_item = i
+        i.show()
+        i.connect("activate", self.ConfigurePiJuice)
+        self.menu.append(i)
 
-		i = gtk.MenuItem("About...")
-		i.show()
-		i.connect("activate", self.show_about)
-		self.menu.append(i)
+        i = gtk.MenuItem("About...")
+        i.show()
+        i.connect("activate", self.show_about)
+        self.menu.append(i)
 
-		self.tray.connect('popup-menu', self.show_menu)
+        self.tray.connect('popup-menu', self.show_menu)
 
-		self.pijuice = PiJuice(1, 0x14)
+        self.pijuice = PiJuice(1, 0x14)
 
-		# Initalise and start battery display
-		self.refresh(None)
-		self.tray.set_visible(True)
+        # Initalise and start battery display
+        self.refresh(None)
+        self.tray.set_visible(True)
 
-		gobject.timeout_add(REFRESH_INTERVAL, self.refresh, self.tray)
-		gobject.timeout_add(CHECK_SIGNAL_INTERVAL, self.check_signum)
+        gobject.timeout_add(REFRESH_INTERVAL, self.refresh, self.tray)
+        gobject.timeout_add(CHECK_SIGNAL_INTERVAL, self.check_signum)
 
-	def show_menu(self, widget, event_button, event_time):
-		if py3 == False:
-			# Python 2
-			self.menu.popup(None, None,
-			gtk.status_icon_position_menu,
-			event_button,
-			event_time,
-			self.tray)
-		else:
-			# Python 3
-			self.menu.popup(None, None,
-			self.tray.position_menu,
-			self.tray,
-			event_button,
-			gtk.get_current_event_time())
+    def show_menu(self, widget, event_button, event_time):
+        if py3 == False:
+            # Python 2
+            self.menu.popup(None, None,
+            gtk.status_icon_position_menu,
+            event_button,
+            event_time,
+            self.tray)
+        else:
+            # Python 3
+            self.menu.popup(None, None,
+            self.tray.position_menu,
+            self.tray,
+            event_button,
+            gtk.get_current_event_time())
 
-	def show_about(self, widget):
-		widget.set_sensitive(False)
-		sw_version, fw_version, os_version = get_versions()
-		if fw_version is None:
-			fw_version = "No connection to PiJuice"
-		message = "\n".join([
-			"Software version: %s" % sw_version,
-			"Firmware version: %s" % fw_version,
-			"OS version: %s" % os_version,
-		])
-		if py3 == False:
-			# Python 2
-			dialog = gtk.MessageDialog(
-				None,
-				gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
-				gtk.MESSAGE_INFO,
-				gtk.BUTTONS_OK,
-				message
-			)
-		else:
-			# Python 3
-			dialog = gtk.MessageDialog(
-				None,
-				gtk.DialogFlags.MODAL,
-				gtk.MessageType.INFO,
-				gtk.ButtonsType.OK,
-				message
-			)
-		dialog.set_title("About")
-		dialog.run()
-		dialog.destroy()
-		widget.set_sensitive(True)
+    def show_about(self, widget):
+        widget.set_sensitive(False)
+        sw_version, fw_version, os_version = get_versions()
+        if fw_version is None:
+            fw_version = "No connection to PiJuice"
+        message = "\n".join([
+            "Software version: %s" % sw_version,
+            "Firmware version: %s" % fw_version,
+            "OS version: %s" % os_version,
+        ])
+        if py3 == False:
+            # Python 2
+            dialog = gtk.MessageDialog(
+                None,
+                gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
+                gtk.MESSAGE_INFO,
+                gtk.BUTTONS_OK,
+                message
+            )
+        else:
+            # Python 3
+            dialog = gtk.MessageDialog(
+                None,
+                gtk.DialogFlags.MODAL,
+                gtk.MessageType.INFO,
+                gtk.ButtonsType.OK,
+                message
+            )
+        dialog.set_title("About")
+        dialog.run()
+        dialog.destroy()
+        widget.set_sensitive(True)
 
-	def ConfigurePiJuice(self, widget):
-		p = Process(target=start_app)
-		p.start()
+    def ConfigurePiJuice(self, widget):
+        p = Process(target=start_app)
+        p.start()
 
-	def check_signum(self):
-		global sig
-		if sig > 0:
-			if sig == SIGUSR1:
-				self.settings_item.set_sensitive(False)
-				sig = -1
-			elif sig == SIGUSR2:
-				self.settings_item.set_sensitive(True)
-				sig = -1
-			else:
-				sig = -1
-		return True
+    def check_signum(self):
+        global sig
+        if sig > 0:
+            if sig == SIGUSR1:
+                self.settings_item.set_sensitive(False)
+                sig = -1
+            elif sig == SIGUSR2:
+                self.settings_item.set_sensitive(True)
+                sig = -1
+            else:
+                sig = -1
+        return True
 
-	def refresh(self, widget):
-		try:
-			charge = self.pijuice.status.GetChargeLevel()
+    def refresh(self, widget):
+        try:
+            charge = self.pijuice.status.GetChargeLevel()
 
-			if charge['error'] == 'NO_ERROR':
-				b_level = charge['data']
-				print('{}%'.format(b_level))
-			else:
-				print(charge)
+            if charge['error'] == 'NO_ERROR':
+                b_level = charge['data']
+                print('{}%'.format(b_level))
+            else:
+                print(charge)
 
-			b_file = ICON_DIR + '/battery_near_full.png'
+            b_file = ICON_DIR + '/battery_near_full.png'
 
-			status = self.pijuice.status.GetStatus()
-			if status['error'] == 'NO_ERROR':
-				self.status = status['data']
+            status = self.pijuice.status.GetStatus()
+            if status['error'] == 'NO_ERROR':
+                self.status = status['data']
 
-				if self.status['battery'] == 'NOT_PRESENT':
-					if self.status['powerInput'] != 'NOT_PRESENT':
-						b_file = ICON_DIR + '/no-bat-in-0.png'
-					else:
-						b_file = ICON_DIR + '/no-bat-rpi-0.png'
+                if self.status['battery'] == 'NOT_PRESENT':
+                    if self.status['powerInput'] != 'NOT_PRESENT':
+                        b_file = ICON_DIR + '/no-bat-in-0.png'
+                    else:
+                        b_file = ICON_DIR + '/no-bat-rpi-0.png'
 
-				elif self.status['battery'] == 'CHARGING_FROM_IN' or self.status['powerInput'] != 'NOT_PRESENT':
-					b_file = ICON_DIR + '/bat-in-' + str((b_level//10)*10) + '.png'
-				elif self.status['battery'] == 'CHARGING_FROM_5V_IO' or self.status['powerInput5vIo'] != 'NOT_PRESENT':
-					b_file = ICON_DIR + '/bat-rpi-' + str((b_level/10)*10) + '.png'
-				else:
-					b_file = ICON_DIR + '/bat-' + str((b_level/10)*10) + '.png'
-			else:
-				b_file = ICON_DIR + '/connection-error.png'
-				if py3 == False:
-					# Python 2
-					self.tray.set_blinking(b_level < 5)
+                elif self.status['battery'] == 'CHARGING_FROM_IN' or self.status['powerInput'] != 'NOT_PRESENT':
+                    b_file = ICON_DIR + '/bat-in-' + str((b_level//10)*10) + '.png'
+                elif self.status['battery'] == 'CHARGING_FROM_5V_IO' or self.status['powerInput5vIo'] != 'NOT_PRESENT':
+                    b_file = ICON_DIR + '/bat-rpi-' + str((b_level/10)*10) + '.png'
+                else:
+                    b_file = ICON_DIR + '/bat-' + str((b_level/10)*10) + '.png'
+            else:
+                b_file = ICON_DIR + '/connection-error.png'
+                if py3 == False:
+                    # Python 2
+                    self.tray.set_blinking(b_level < 5)
 
-			self.tray.set_tooltip_text("%d%%" % (b_level))
-			if os.path.exists(b_file):
-				self.tray.set_from_file(b_file)
-			else:
-				print(b_file)
-				print('icon file not exist')
+            self.tray.set_tooltip_text("%d%%" % (b_level))
+            if os.path.exists(b_file):
+                self.tray.set_from_file(b_file)
+            else:
+                print(b_file)
+                print('icon file not exist')
 
-		except:
-			print('refresh error')
-		return True
+        except:
+            print('refresh error')
+        return True
 
 def receive_signal(signum, stack):
-	global sig
-	if signum == SIGUSR1 or signum == SIGUSR2:
-		sig = signum
-	else:
-		sig = -1
+    global sig
+    if signum == SIGUSR1 or signum == SIGUSR2:
+        sig = signum
+    else:
+        sig = -1
 
 if __name__ == '__main__':
-	global sig
+    global sig
 
-	sig = -1
+    sig = -1
 
-	# Make our pid available for pijuice_gui
-	pid = os.getpid()
-	with open(TRAY_PID_FILE, 'w') as f:
-		f.write(str(pid))
+    # Make our pid available for pijuice_gui
+    pid = os.getpid()
+    with open(TRAY_PID_FILE, 'w') as f:
+        f.write(str(pid))
 
-	# Set up signal handlers.
-	# SIGUSR1 to disable the Settings menu item
-	# SIGUSR2 to enable the Settings menu item
-	signal(SIGUSR1, receive_signal)
-	signal(SIGUSR2, receive_signal)
+    # Set up signal handlers.
+    # SIGUSR1 to disable the Settings menu item
+    # SIGUSR2 to enable the Settings menu item
+    signal(SIGUSR1, receive_signal)
+    signal(SIGUSR2, receive_signal)
 
-	app = PiJuiceStatusTray()
-	gtk.main()
+    app = PiJuiceStatusTray()
+    gtk.main()

--- a/Software/Source/src/pijuice_tray.py
+++ b/Software/Source/src/pijuice_tray.py
@@ -1,20 +1,25 @@
-#!/usr/bin/env python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
+from __future__ import print_function, division
 
 import os
 import os.path
 import sys
-import time
+from time import sleep
 from glob import glob
 from multiprocessing import Process
+from signal import signal, SIGUSR1, SIGUSR2
 
-try:
+py3 = sys.version_info > (3, 0)
+
+if py3 == False:
 	# Python 2
 	import gtk
 	import gobject
-except ImportError:
+else:
 	# Python 3
+	import gi
+	gi.require_version('Gtk', '3.0')
 	from gi.repository import Gtk as gtk
 	from gi.repository import GObject as gobject
 
@@ -22,7 +27,9 @@ from pijuice import PiJuice, get_versions
 from pijuice_gui import start_app
 
 REFRESH_INTERVAL = 5000
+CHECK_SIGNAL_INTERVAL = 200
 ICON_DIR = '/usr/share/pijuice/data/images'
+TRAY_PID_FILE = '/tmp/pijuice_tray.pid'
 
 
 class PiJuiceStatusTray(object):
@@ -32,19 +39,20 @@ class PiJuiceStatusTray(object):
 		self.tray.connect('activate', self.refresh)
 
 		# Create menu
-		menu = gtk.Menu()
+		self.menu = gtk.Menu()
 
 		i = gtk.MenuItem("Settings")
+		self.settings_item = i
 		i.show()
 		i.connect("activate", self.ConfigurePiJuice)
-		menu.append(i)
+		self.menu.append(i)
 
 		i = gtk.MenuItem("About...")
 		i.show()
 		i.connect("activate", self.show_about)
-		menu.append(i)
+		self.menu.append(i)
 
-		self.tray.connect('popup-menu', self.show_menu, menu)
+		self.tray.connect('popup-menu', self.show_menu)
 
 		self.pijuice = PiJuice(1, 0x14)
 
@@ -52,17 +60,27 @@ class PiJuiceStatusTray(object):
 		self.refresh(None)
 		self.tray.set_visible(True)
 
-		gobject.timeout_add(REFRESH_INTERVAL, self.refresh, False)
+		gobject.timeout_add(REFRESH_INTERVAL, self.refresh, self.tray)
+		gobject.timeout_add(CHECK_SIGNAL_INTERVAL, self.check_signum)
 
-	def show_menu(self, widget, event_button, event_time, menu):
-		menu.popup(None, None,
-                    gtk.status_icon_position_menu,
-                    event_button,
-                    event_time,
-                    self.tray
-             )
+	def show_menu(self, widget, event_button, event_time):
+		if py3 == False:
+			# Python 2
+			self.menu.popup(None, None,
+			gtk.status_icon_position_menu,
+			event_button,
+			event_time,
+			self.tray)
+		else:
+			# Python 3
+			self.menu.popup(None, None,
+			self.tray.position_menu,
+			self.tray,
+			event_button,
+			gtk.get_current_event_time())
 
 	def show_about(self, widget):
+		widget.set_sensitive(False)
 		sw_version, fw_version, os_version = get_versions()
 		if fw_version is None:
 			fw_version = "No connection to PiJuice"
@@ -71,20 +89,45 @@ class PiJuiceStatusTray(object):
 			"Firmware version: %s" % fw_version,
 			"OS version: %s" % os_version,
 		])
-		dialog = gtk.MessageDialog(
-			None,
-			gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
-			gtk.MESSAGE_INFO,
-			gtk.BUTTONS_OK,
-			message
-		)
+		if py3 == False:
+			# Python 2
+			dialog = gtk.MessageDialog(
+				None,
+				gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
+				gtk.MESSAGE_INFO,
+				gtk.BUTTONS_OK,
+				message
+			)
+		else:
+			# Python 3
+			dialog = gtk.MessageDialog(
+				None,
+				gtk.DialogFlags.MODAL,
+				gtk.MessageType.INFO,
+				gtk.ButtonsType.OK,
+				message
+			)
 		dialog.set_title("About")
 		dialog.run()
 		dialog.destroy()
+		widget.set_sensitive(True)
 
 	def ConfigurePiJuice(self, widget):
 		p = Process(target=start_app)
 		p.start()
+
+	def check_signum(self):
+		global sig
+		if sig > 0:
+			if sig == SIGUSR1:
+				self.settings_item.set_sensitive(False)
+				sig = -1
+			elif sig == SIGUSR2:
+				self.settings_item.set_sensitive(True)
+				sig = -1
+			else:
+				sig = -1
+		return True
 
 	def refresh(self, widget):
 		try:
@@ -96,11 +139,9 @@ class PiJuiceStatusTray(object):
 			else:
 				print(charge)
 
-			# "." + str(b_level / 10) + ".png"
 			b_file = ICON_DIR + '/battery_near_full.png'
 
 			status = self.pijuice.status.GetStatus()
-			#print status
 			if status['error'] == 'NO_ERROR':
 				self.status = status['data']
 
@@ -111,30 +152,50 @@ class PiJuiceStatusTray(object):
 						b_file = ICON_DIR + '/no-bat-rpi-0.png'
 
 				elif self.status['battery'] == 'CHARGING_FROM_IN' or self.status['powerInput'] != 'NOT_PRESENT':
-					b_file = ICON_DIR + '/bat-in-' + str((b_level/10)*10) + '.png'
+					b_file = ICON_DIR + '/bat-in-' + str((b_level//10)*10) + '.png'
 				elif self.status['battery'] == 'CHARGING_FROM_5V_IO' or self.status['powerInput5vIo'] != 'NOT_PRESENT':
 					b_file = ICON_DIR + '/bat-rpi-' + str((b_level/10)*10) + '.png'
 				else:
 					b_file = ICON_DIR + '/bat-' + str((b_level/10)*10) + '.png'
 			else:
 				b_file = ICON_DIR + '/connection-error.png'
-				try:
+				if py3 == False:
+					# Python 2
 					self.tray.set_blinking(b_level < 5)
-				except AttributeError:
-					# XXX: Fix for Python 3
-					pass
 
 			self.tray.set_tooltip_text("%d%%" % (b_level))
 			if os.path.exists(b_file):
 				self.tray.set_from_file(b_file)
 			else:
+				print(b_file)
 				print('icon file not exist')
 
 		except:
-			print('charge proccess error')
+			print('refresh error')
 		return True
 
+def receive_signal(signum, stack):
+	global sig
+	if signum == SIGUSR1 or signum == SIGUSR2:
+		sig = signum
+	else:
+		sig = -1
 
 if __name__ == '__main__':
+	global sig
+
+	sig = -1
+
+	# Make our pid available for pijuice_gui
+	pid = os.getpid()
+	with open(TRAY_PID_FILE, 'w') as f:
+		f.write(str(pid))
+
+	# Set up signal handlers.
+	# SIGUSR1 to disable the Settings menu item
+	# SIGUSR2 to enable the Settings menu item
+	signal(SIGUSR1, receive_signal)
+	signal(SIGUSR2, receive_signal)
+
 	app = PiJuiceStatusTray()
 	gtk.main()


### PR DESCRIPTION
Pijuice_tray.py:
- Make Python 3 compatible
- Allow only a single instance of About by disabling the About menu item
  while the About message is open
- Allow only a single instance of Pijuice Settings (pijuice_gui.py) by
  disabling the Settings menu item (Also when PiJuice Settings is
started
  from the Preferences)

Pijuice_gui.py
- Communicate to pijuice_tray.py when pijuice_gui is started and
finished
  using Unix signals (SIGUSR1 at start, SIGUSR2 at end)
- Use lock file to only allow only one instance of pijuice_gui running.
  (pijuice_gui can be started multiple times from Preferences)
- Allow only one HAT configuration window by disabling the 'Configure HAT' button when
  the HAT configuration window is active.