### PR TITLE
Pijuice external software halt, power off

### DIFF
--- a/Software/README.md
+++ b/Software/README.md
@@ -156,6 +156,7 @@ To test the script simply disable the wakeup alarm in the GUI then reboot your R
 ### System Task Menu
 
 ![System Task Menu](https://user-images.githubusercontent.com/16068311/35161236-7d4e6f56-fd37-11e7-9209-7943e88a76d5.png "System Task Menu")
+**OUTDATED IMAGE**
 
 Here we have the system task menu tab. This enables you to set the external watchdog timer - useful for remote applications where you can't come and do a hard-reset yourself if the Pi crashes or hangs. The PiJuice essentially monitors for a "heart beat" from the software - if it does not sense it after a defined period of time it automatically resets the Raspberry Pi. You can also set here wakeup on charge levels, minimum battery levels and voltages.
 
@@ -166,6 +167,9 @@ The watchdog timer has a configurable time-out. It defines the time after which 
 * **Wakeup on charge** - Set a percentage battery value when to wakeup the Raspberry Pi whilst on charge. Usually this value would be high, between 90-100%. This is usually used in-conjunction with "Minimum charge".
 * **Minimum charge** - Set a minimum battery percentage level to safely shutdown the Raspberry Pi when the battery is below this value. Low values should be typically between 5-10%. NOTE: The type of system shutdown can be set under "System Events" under "Low charge" menu.
 * **Minimum battery voltage** - Set a minimum battery voltage level to safely shutdown the Raspberry Pi when below the set level. Note: The type of system shutdown can be set under "System Events" under "Low battery voltage" menu.
+* **Software Halt Power Off** - You can set a delay here in seconds (maximum of 65535) as to when to cut power to the Raspberry Pi when a software shutdown has occurred external to a button press. Usually this would occur when a user has run sudo halt, sudo shutdown -h now, or sudo poweroff in the terminal.
+
+**Note: Software Halt Power Off will cut power at the end of the delay period. Provide an above normal amount of time for the OS to complete shutdown or the SD card may be CORRUPTED.  RECOMMEND 30 or more seconds.**
 
 ### System Events Menu
 
@@ -630,6 +634,10 @@ here is an example of a configuration.
     "wakeup_on_charge": {
       "enabled": true,
       "trigger_level": "1"
+    },
+    "ext_halt_power_off": {
+      "enabled": true,
+      "period": "30"
     }
   }
 }
@@ -668,8 +676,13 @@ Here is a list of accepted values for the various fields above.
     - wakeup_on_charge
         - enabled: true, false
         - trigger_level (%): 0..100
+    - ext_halt_power_off
+        - enabled: true, false
+        - period (seconds): 10..65535
 * **user_functions**:
     - absolute path to user defined script
+
+**Note: ext_halt_power_off will cut power at the end of the period. Provide above normal amount of time for OS to complete shutdown or the SD card may be CORRUPTED.  RECOMMEND 30 or more seconds.**
 
 ### Adding USER_FUNC from 9 to 15
 
@@ -748,7 +761,8 @@ Returns:
 'isButton':is_button,
 'battery':battery_status,
 'powerInput':power_input_status,
-'powerInput5vIo':5v_power_input_status
+'powerInput5vIo':5v_power_input_status,
+'isHalting':is_halting
 }
 Where:
 * is_fault is True if there faults or fault events waiting to be read or False if there is no faults and no fault events.
@@ -756,12 +770,13 @@ Where:
 * battery_status is string constant that describes current battery status, one of four: 'NORMAL', 'CHARGING_FROM_IN', 'CHARGING_FROM_5V_IO', 'NOT_PRESENT'.
 * power_input_status is string constant that describes current status of USB Micro power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
 * 5v_power_input_status: is string constant that describes current status of 5V GPIO power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
+* is_halting: is False during all normal operation or True when PiJuice has issued a halt to the OS which only perists until OS restarts
 Example:
 ```python
 print pijuice.status.GetStatus()
 ```
 Returns:
-`{'data': {'battery': 'CHARGING_FROM_5V_IO', 'powerInput5vIo': 'PRESENT', 'isFault': False, 'isButton': False, 'powerInput': 'NOT_PRESENT'}, 'error': 'NO_ERROR'}`
+`{'data': {'battery': 'CHARGING_FROM_5V_IO', 'powerInput5vIo': 'PRESENT', 'isFault': False, 'isButton': False, 'isHalting': False, 'powerInput': 'NOT_PRESENT'}, 'error': 'NO_ERROR'}`
 
 **GetChargeLevel()**
 

--- a/Software/README.md
+++ b/Software/README.md
@@ -155,8 +155,7 @@ To test the script simply disable the wakeup alarm in the GUI then reboot your R
 
 ### System Task Menu
 
-![System Task Menu](https://user-images.githubusercontent.com/16068311/35161236-7d4e6f56-fd37-11e7-9209-7943e88a76d5.png "System Task Menu")
-**OUTDATED IMAGE**
+![System Task Menu](https://user-images.githubusercontent.com/17354856/46268663-4ea6e600-c501-11e8-9a17-eccfb32dedaa.png "System Task Menu")
 
 Here we have the system task menu tab. This enables you to set the external watchdog timer - useful for remote applications where you can't come and do a hard-reset yourself if the Pi crashes or hangs. The PiJuice essentially monitors for a "heart beat" from the software - if it does not sense it after a defined period of time it automatically resets the Raspberry Pi. You can also set here wakeup on charge levels, minimum battery levels and voltages.
 
@@ -761,22 +760,20 @@ Returns:
 'isButton':is_button,
 'battery':battery_status,
 'powerInput':power_input_status,
-'powerInput5vIo':5v_power_input_status,
-'isHalting':is_halting
+'powerInput5vIo':5v_power_input_status
 }
 Where:
 * is_fault is True if there faults or fault events waiting to be read or False if there is no faults and no fault events.
 * is_button is True if there are button events, False if not.
 * battery_status is string constant that describes current battery status, one of four: 'NORMAL', 'CHARGING_FROM_IN', 'CHARGING_FROM_5V_IO', 'NOT_PRESENT'.
 * power_input_status is string constant that describes current status of USB Micro power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
-* 5v_power_input_status is string constant that describes current status of 5V GPIO power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
-* is_halting is False during all normal operation or True when PiJuice has issued a halt to the OS which only perists until OS restarts.
+* 5v_power_input_status: is string constant that describes current status of 5V GPIO power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
 Example:
 ```python
 print pijuice.status.GetStatus()
 ```
 Returns:
-`{'data': {'battery': 'CHARGING_FROM_5V_IO', 'powerInput5vIo': 'PRESENT', 'isFault': False, 'isButton': False, 'isHalting': False, 'powerInput': 'NOT_PRESENT'}, 'error': 'NO_ERROR'}`
+`{'data': {'battery': 'CHARGING_FROM_5V_IO', 'powerInput5vIo': 'PRESENT', 'isFault': False, 'isButton': False, 'powerInput': 'NOT_PRESENT'}, 'error': 'NO_ERROR'}`
 
 **GetChargeLevel()**
 

--- a/Software/README.md
+++ b/Software/README.md
@@ -169,7 +169,7 @@ The watchdog timer has a configurable time-out. It defines the time after which 
 * **Minimum battery voltage** - Set a minimum battery voltage level to safely shutdown the Raspberry Pi when below the set level. Note: The type of system shutdown can be set under "System Events" under "Low battery voltage" menu.
 * **Software Halt Power Off** - You can set a delay here in seconds (maximum of 65535) as to when to cut power to the Raspberry Pi when a software shutdown has occurred external to a button press. Usually this would occur when a user has run sudo halt, sudo shutdown -h now, or sudo poweroff in the terminal.
 
-**Note: Software Halt Power Off will cut power at the end of the delay period. Provide an above normal amount of time for the OS to complete shutdown or the SD card may be CORRUPTED.  RECOMMEND 30 or more seconds.**
+**NOTE: Software Halt Power Off** will cut power at the end of the delay period. Provide an above normal amount of time for the OS to complete shutdown or the SD card may be CORRUPTED.  **RECOMMEND 30 or more seconds.**
 
 ### System Events Menu
 
@@ -682,7 +682,7 @@ Here is a list of accepted values for the various fields above.
 * **user_functions**:
     - absolute path to user defined script
 
-**Note: ext_halt_power_off will cut power at the end of the period. Provide above normal amount of time for OS to complete shutdown or the SD card may be CORRUPTED.  RECOMMEND 30 or more seconds.**
+**NOTE: ext_halt_power_off will cut power at the end of the period. Provide above normal amount of time for OS to complete shutdown or the SD card may be CORRUPTED.  RECOMMEND 30 or more seconds.**
 
 ### Adding USER_FUNC from 9 to 15
 
@@ -769,8 +769,8 @@ Where:
 * is_button is True if there are button events, False if not.
 * battery_status is string constant that describes current battery status, one of four: 'NORMAL', 'CHARGING_FROM_IN', 'CHARGING_FROM_5V_IO', 'NOT_PRESENT'.
 * power_input_status is string constant that describes current status of USB Micro power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
-* 5v_power_input_status: is string constant that describes current status of 5V GPIO power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
-* is_halting: is False during all normal operation or True when PiJuice has issued a halt to the OS which only perists until OS restarts
+* 5v_power_input_status is string constant that describes current status of 5V GPIO power input, one of four: 'NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT'.
+* is_halting is False during all normal operation or True when PiJuice has issued a halt to the OS which only perists until OS restarts.
 Example:
 ```python
 print pijuice.status.GetStatus()

--- a/Software/Source/pijuice.py
+++ b/Software/Source/pijuice.py
@@ -211,7 +211,6 @@ class PiJuiceStatus(object):
     LED_STATE_CMD = 0x66
     LED_BLINK_CMD = 0x68
     IO_PIN_ACCESS_CMD = 0x75
-    __IS_HALTING = False
 
     def __init__(self, interface):
         self.interface = interface
@@ -238,11 +237,7 @@ class PiJuiceStatus(object):
             powerInStatusEnum = ['NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT']
             status['powerInput'] = powerInStatusEnum[(d >> 4) & 0x03]
             status['powerInput5vIo'] = powerInStatusEnum[(d >> 6) & 0x03]
-            status['isHalting'] = self.__IS_HALTING
             return {'data': status, 'error': 'NO_ERROR'}
-
-    def SetHaltFlag(self):
-        self.__IS_HALTING = True
 
     def GetChargeLevel(self):
         result = self.interface.ReadData(self.CHARGE_LEVEL_CMD, 1)

--- a/Software/Source/pijuice.py
+++ b/Software/Source/pijuice.py
@@ -211,6 +211,7 @@ class PiJuiceStatus(object):
     LED_STATE_CMD = 0x66
     LED_BLINK_CMD = 0x68
     IO_PIN_ACCESS_CMD = 0x75
+    __IS_HALTING = False
 
     def __init__(self, interface):
         self.interface = interface
@@ -237,7 +238,11 @@ class PiJuiceStatus(object):
             powerInStatusEnum = ['NOT_PRESENT', 'BAD', 'WEAK', 'PRESENT']
             status['powerInput'] = powerInStatusEnum[(d >> 4) & 0x03]
             status['powerInput5vIo'] = powerInStatusEnum[(d >> 6) & 0x03]
+            status['isHalting'] = self.__IS_HALTING
             return {'data': status, 'error': 'NO_ERROR'}
+
+    def SetHaltFlag(self):
+        self.__IS_HALTING = True
 
     def GetChargeLevel(self):
         result = self.interface.ReadData(self.CHARGE_LEVEL_CMD, 1)

--- a/Software/Source/src/pijuice_gui.py
+++ b/Software/Source/src/pijuice_gui.py
@@ -1601,6 +1601,7 @@ class PiJuiceSysTaskTab(object):
         self.wakeupChargeParam = PiJuiceConfigParamEdit(self.frame, 4, pijuiceConfigData['system_task'], "Wakeup on charge", "Trigger level [%]:", 'wakeup_on_charge', 'trigger_level', 'int', 0, 100)
         self.minChargeParam = PiJuiceConfigParamEdit(self.frame, 6, pijuiceConfigData['system_task'], "Minimum charge", "Threshold [%]:", 'min_charge', 'threshold', 'int', 0, 100)
         self.minVoltageParam = PiJuiceConfigParamEdit(self.frame, 8, pijuiceConfigData['system_task'], "Minimum battery voltage", "Threshold [V]:", 'min_bat_voltage', 'threshold', 'float', 0, 10)
+        self.extHaltParam = PiJuiceConfigParamEdit(self.frame, 10, pijuiceConfigData['system_task'], "Software Halt Power Off", "Delay period [seconds]:", 'ext_halt_power_off', 'period', 'int', 1, 65535)
 
         if ('enabled' in pijuiceConfigData['system_task']) and (pijuiceConfigData['system_task']['enabled'] == True):
             self.sysTaskEnable.set(True)

--- a/Software/Source/src/pijuice_gui.py
+++ b/Software/Source/src/pijuice_gui.py
@@ -1586,7 +1586,7 @@ class PiJuiceSysTaskTab(object):
     def __init__(self, master):
         self.frame = Frame(master, name='sys_task')
         self.frame.grid(row=0, column=0, sticky=W)
-        self.frame.rowconfigure(10, weight=1)
+        self.frame.rowconfigure(12, weight=1)
         self.frame.columnconfigure(0, weight=0, minsize=190)
         self.frame.columnconfigure(1, weight=10, uniform=1)
         self.frame.columnconfigure(2, weight=1, uniform=1)
@@ -1776,7 +1776,7 @@ class PiJuiceConfigGui(Frame):
         for i in range(0, 15):
             self.userScriptTab._UpdatePath(i)
         # Apply system task params
-        for param in (self.sysTaskConfig.watchdogParam, self.sysTaskConfig.wakeupChargeParam, self.sysTaskConfig.minChargeParam, self.sysTaskConfig.minVoltageParam):
+        for param in (self.sysTaskConfig.watchdogParam, self.sysTaskConfig.wakeupChargeParam, self.sysTaskConfig.minChargeParam, self.sysTaskConfig.minVoltageParam, self.sysTaskConfig.extHaltParam):
             param._WriteParam(None)
         save_config()
 

--- a/Software/Source/src/pijuice_sys.py
+++ b/Software/Source/src/pijuice_sys.py
@@ -225,7 +225,7 @@ def main():
                     ret = pijuice.power.SetWatchdog(0)
         except:
             pass
-        sysJobTargets = subprocess.check_output(["systemctl", "list-jobs"])
+        sysJobTargets = str(subprocess.check_output(["systemctl", "list-jobs"]))
         reboot = True if re.search('reboot.target.*start', sysJobTargets) is not None else False                      # reboot.target exists
         swStop = True if re.search('(?:halt|shutdown).target.*start', sysJobTargets) is not None else False           # shutdown | halt exists
         causePowerOff = True if (swStop and not reboot) else False
@@ -236,12 +236,12 @@ def main():
         	and configData.get('system_task',{}).get('ext_halt_power_off', {}).get('enabled',False)
         	):
         	# Set duration for when pijuice will cut power (Recommended 30+ sec, for halt to complete)
-                try:
-        	   powerOffDelay = int(configData['system_task']['ext_halt_power_off'].get('period',30))
-        	   pijuice.power.SetPowerOff(powerOffDelay)
-                   print("PiJuice powering off in %s seconds" % configData['system_task']['ext_halt_power_off'].get('period',30))
-                except ValueError:
-                   pass
+            try:
+                powerOffDelay = int(configData['system_task']['ext_halt_power_off'].get('period',30))
+                pijuice.power.SetPowerOff(powerOffDelay)
+                print("PiJuice powering off in %s seconds" % configData['system_task']['ext_halt_power_off'].get('period',30))
+            except ValueError:
+                pass
         sys.exit(0)
 
     if (('watchdog' in configData['system_task'])


### PR DESCRIPTION
This feature addition adds a system task flag and adjustable delay control for power off of the pijuice module.  This modification is similar to the SYS_FUNC_HALT_POW_OFF system function where power is supplied for 60 seconds after a system halt is sent to the Raspberry Pi.  The variance here is that the pijuice_sys.py script detects any halt, shutdown, or poweroff issued by any other software external to pijuice actions (SSH, GNOME desktop, etc) and will provide power for a delay after shutdown command.  The delay is provided in seconds and the clock starts when the 'pijuice.service stop' is issued by systemd during shutdown.

Reboot is ignored and any other pijuice module/software generated effects occur as configured by user.  This is possible since the script verifies the existence of systemd target's such as reboot.target.*start and shutdown.target.*start.

This is a great supplement for users who are already using the SYS_FUNC_HALT_POW_OFF function for their button actions but also have the possibility of using SSH to remotely shutdown the device for a full power off.

The Software Readme has been updated to reflect how to use this function and below is the image to replace the screenshot of the System Task Settings Menu.

Updated Image to include. (No similar way for me to upload image until now, see url below)
![System Task Menu Screenshot](https://user-images.githubusercontent.com/17354856/46268663-4ea6e600-c501-11e8-9a17-eccfb32dedaa.png)
