### PR TITLE
Modify systemd service file to start after syslog instead of network.…

### DIFF
--- a/Software/Source/debian-base/pijuice.service
+++ b/Software/Source/debian-base/pijuice.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=PiJuice status service
-After=network.target
+After=syslog.target
 
 [Service]
 Type=idle


### PR DESCRIPTION
Enabling wake on power without network connected creates boot loops without this.