### PR TITLE
a little fix on using apt to install packets from local source

### DIFF
--- a/Software/OS Support/ubuntu_server_64.MD
+++ b/Software/OS Support/ubuntu_server_64.MD
@@ -31,13 +31,13 @@ sudo rm -rf PiJuice
 2. Install the localpijuice-base:
 ```
 cd $HOME
-sudo apt install pijuice-base_1.6_all.deb
+sudo apt install ./pijuice-base_1.6_all.deb
 ```
 
 3. Install the local pijuice-gui (if needed):
 ```
 cd $HOME
-sudo apt install pijuice-gui_1.6_all.deb
+sudo apt install ./pijuice-gui_1.6_all.deb
 ```
 
 4. Fix broken packages:\


### PR DESCRIPTION
using apt for local installing of deb-packets needs ./ bevor the packet