### PR TITLE
Log connection errors

### DIFF
--- a/Software/Source/src/pijuice_sys.py
+++ b/Software/Source/src/pijuice_sys.py
@@ -284,7 +284,8 @@ def _LoadConfiguration():
                 bus = configData['board']['general']['i2c_bus']
         pijuice = PiJuice(bus, addr)
     except:
-        sys.exit(0)
+        print("Failed to connect with error '%s'" % e)
+        sys.exit(1)
 
     try:
         for b in pijuice.config.buttons:


### PR DESCRIPTION
This change updates pijuice_sys.py to exit with an error when failing to connect to the PiJuice, and logs the associated error.

I was finding it hard to debug multiple service restarts as a result of i2c permission errors on my system. This logging significantly helped me figure out what was going on; hopefully it's useful to others too.