### PR TITLE
Wake up the clock before loading rtc_ds1307 module

### DIFF
--- a/Software/Source/src/pijuice_sys.py
+++ b/Software/Source/src/pijuice_sys.py
@@ -387,7 +387,12 @@ def main():
                     time.sleep(pause)
                     timeout -= pause
                 if timeout <= 0:
-                    print('RTC hardware not responding, try to load rtc_ds1307 anyway', flush=True)
+                    print('RTC hardware not responding, trying to load rtc_ds1307 anyway', flush=True)
+                else:
+                    if pijuice.rtcAlarm.GetTime()['data']['year'] == 2000:
+                        print('RTC clock was reset to 0. Possible battery loss.')
+                        print('Setting RTC to current system time')
+                        pijuice.rtcAlarm.SetTime(None)
 
                 ret = os.system('sudo modprobe rtc_ds1307')
                 if (ret != 0):

--- a/Software/Source/src/pijuice_sys.py
+++ b/Software/Source/src/pijuice_sys.py
@@ -39,8 +39,8 @@ sysStopEvEn = False
 noPowCnt = 0  # 0 will trigger at boot without power, 3 will not trigger at boot without power
 PowCnt = 3    # 0 will trigger at boot with power, 3 will not trigger at boot with power
 dopoll = True
-PID_FILE = '/tmp/pijuice_sys.pid'
-HALT_FILE = '/tmp/pijuice_halt.flag'
+PID_FILE = '/run/pijuice/pijuice_sys.pid'
+HALT_FILE = '/run/pijuice/pijuice_halt.flag'
 I2C_ADDRESS_DEFAULT = 0x14
 I2C_BUS_DEFAULT = 1
 
@@ -284,6 +284,7 @@ def _LoadConfiguration():
                 bus = configData['board']['general']['i2c_bus']
         pijuice = PiJuice(bus, addr)
     except:
+        print("Failed to connect to PiJuice with: {}".format(configPath))
         sys.exit(0)
 
     try:
@@ -352,6 +353,7 @@ def main():
                 pijuice.power.SetPowerOff(powerOffDelay)
             except ValueError:
                 pass
+        os.remove(PID_FILE)
         sys.exit(0)
 
     # First check if rtc is operational when the rtc_ds1307 module is loaded.
@@ -403,6 +405,8 @@ def main():
                         print('rtc_ds1307 module reloaded and RTC os-support OK', flush=True)
                     else:
                         print('RTC os-support not available', flush=True)
+    else:
+        print('RTC os-support not available', flush=True)
 
     if watchdogEn: _ConfigureWatchdog('ACTIVATE')
 

--- a/Software/Source/src/pijuice_sys.py
+++ b/Software/Source/src/pijuice_sys.py
@@ -381,12 +381,21 @@ def main():
             if ret != 0:
                 print('Remove rtc_ds1307 module failed', flush=True)
             else:
+                print('Wake up RTC hardware', flush=True)
+                timeout, pause = 100, 0.1
+                while pijuice.rtcAlarm.GetTime()['error'] != 'NO_ERROR' and timeout > 0:
+                    time.sleep(pause)
+                    timeout -= pause
+                if timeout <= 0:
+                    print('RTC hardware not responding, try to load rtc_ds1307 anyway', flush=True)
+
                 ret = os.system('sudo modprobe rtc_ds1307')
                 if (ret != 0):
                     print('Reload rtc_ds1307 module failed', flush=True)
                 else:
+                    time.sleep(1) # give udev time to create the device
                     if os.path.exists('/dev/rtc'):
-                        print('rtc_ds1307 mdule reloaded and RTC os-support OK', flush=True)
+                        print('rtc_ds1307 module reloaded and RTC os-support OK', flush=True)
                     else:
                         print('RTC os-support not available', flush=True)
 


### PR DESCRIPTION
Under Fedora 39 with kernel 6.5.6, loading the module rtc_ds1307 does not result in a functioning RTC. The clock needs to be read (woken up?) before the module is loaded. This change adds a read of the clock with a timeout.

In addition, the /dev/rtc device file takes a fraction of a second to load so the test for its existence always fails. A 1 second sleep gives time for the file to be created.

It's not clear to me if eventually this will be required for Raspberry OS when it eventually gets to the 6.5.6 kernel. However it seems this change should always work on kernel 5.

Also fix a misspelling of module in the success message.

Tested on Raspberry OS bullseye by copying the pijuice_sys.py file over the old one and restarting the service. Then restarted the RPi checking systemctl status pijuice and sudo hwclock -r. Finally powered off, removed power (without a battery to reset RTC) and booted up. All the same checks and running fine. I have a generic Raspberry OS install running systemd-timesyncd for network time.