### PR TITLE
Update fedora install instructions based on release

### DIFF
--- a/Software/OS Support/fedora_64.MD
+++ b/Software/OS Support/fedora_64.MD
@@ -4,22 +4,7 @@
 https://docs.fedoraproject.org/en-US/quick-docs/raspberry-pi/
 
 ## Configure firmware device tree
-Currently Fedora is configured for kernel device tree which results in a different enumeration of the i2c bus. Also it requires poking sysfs to instantiate rtc_ds1307 module.
-
-1. remove or rename the file /boot/dtb (it's a symlink so it's safe to delete):
-```
-sudo mv /boot/dtb /boot/dtb.disable
-```
-
-2. configure Fedora not to reenable kernel DT on a kernel upgrade
-```
-echo "FirmwareDT=True" | sudo tee -a /etc/u-boot.conf
-```
-
-3. configure the firmware DT to load the ds1307 with i2c
-```
-echo -e "\n# pijuice rtc\ndtoverlay=i2c-rtc,ds1307" | sudo tee -a /boot/efi/config.txt
-```
+While Fedora 39 was in beta kernel device tree, which is the default, was not working and this project required the install be switched to firmware device tree. The issue was resolved just before the Fedora 39 release and now the default kernel device tree works.
 
 ## Install PiJuice Softaware
 The icon-tray app requires GNOME 45 to show in the upper right of the toolbar. Fedora 39 has GNOME 45. 
@@ -42,7 +27,7 @@ sudo dnf install pijuice-base
 sudo dnf install pijuice-gui
 ```
 
-4. Reboot and run PiJuice CLI or PiJuice GUI when on Desktop:\
+4. Reboot and run PiJuice CLI or PiJuice GUI when on Desktop:
 ```
 sudo reboot
 ```


### PR DESCRIPTION
Fedora 39 fixed kernel device tree support so the install instructions can be simplified.